### PR TITLE
Close response body with defer statement in golang code

### DIFF
--- a/examples/golang.go
+++ b/examples/golang.go
@@ -50,6 +50,7 @@ func main() {
 		fmt.Printf("failed to perform GET request: %v", err)
 		os.Exit(1)
 	}
+	defer response.Body.Close()
 
 	responseBodyBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {


### PR DESCRIPTION
As stated in the [http package documentation](https://pkg.go.dev/net/http#ReadResponse):

> Clients must call `resp.Body.Close` when finished reading `resp.Body`.

And as can be seen at the beginning of the documentation for the http package, it is again advised in the exemplary code to close the response body with a defer statement: 

>The client must close the response body when finished with it:
```go
resp, err := http.Get("http://example.com/")
if err != nil {
	// handle error
}
defer resp.Body.Close()
body, err := io.ReadAll(resp.Body)
```

I would add this changes to the official repo, especially since the code could be taken as it is by other developers, to be then integrated into their own codebases, with the pitfall that now the closing of connections is not actually being handled appropriately.